### PR TITLE
Update oc from 3.9 to 3.10; refactor kubectl installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ RUN export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
 RUN set -ex \
  && wget --no-verbose -O kubectl "https://storage.googleapis.com/kubernetes-release/release/v1.11.2/bin/linux/amd64/kubectl" \
  && sudo install ./kubectl /usr/local/bin \
+ && rm kubectl \
  && mkdir -p /home/circleci/.kube \
  && touch /home/circleci/.kube/config \
  && chown -R circleci /home/circleci/.kube/ \


### PR DESCRIPTION
Update `oc` to 3.10 because it is a smaller binary. Refactor `kubectl` since it is nearby.

Image size comparison:
```
$ docker images | grep 0.1.11
stackrox/apollo-ci                                                                   0.1.11-6-gcb0e94637c       3102f9f49e34        About an hour ago   2.39GB
stackrox/apollo-ci                                                                   0.1.11-5-ga819f86257       52c6a3dd90d0        3 hours ago         2.44GB
```