### PR TITLE
Some small quality of life improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,50 +5,39 @@ defaults: &defaults
 
 version: 2
 jobs:
-  sanity:
-    <<: *defaults
-    steps:
-    - checkout
-    - run:
-        name: Check environment for required secrets
-        command: |
-          : ${DOCKERHUB_USERNAME:?}
-          : ${DOCKERHUB_PASSWORD:?}
-    - run:
-        name: Check that current Git ref is describable
-        command: git describe --tags
-
   build:
     <<: *defaults
     steps:
-      - checkout
-      - setup_remote_docker
+    - checkout
+    - setup_remote_docker
 
-      - run:
-          name: Build all
-          command: |
-            export TAG=$(git describe --tags --abbrev=10)
-            docker build -t stackrox/apollo-ci:$TAG .
+    - run:
+        name: Build Docker image
+        command: |
+          export TAG=$(git describe --tags --abbrev=10)
+          docker build \
+            -t stackrox/apollo-ci:snapshot-$TAG \
+            -t stackrox/apollo-ci:$TAG .
 
-      - run:
-          name: Push new Docker image
-          command: |
-            export TAG=$(git describe --tags --abbrev=10)
+    - run:
+        name: Push Docker image
+        command: |
+          docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
 
-            docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
-            docker push stackrox/apollo-ci:$TAG | cat
+          export TAG=$(git describe --tags --abbrev=10)
+          if [[ $CIRCLE_BRANCH = master || -n $CIRCLE_TAG ]]; then
+            echo Pushing release images
+            docker push stackrox/apollo-ci:$TAG
+          else
+            echo Pushing snapshot images
+            docker push stackrox/apollo-ci:snapshot-$TAG
+          fi
 
 workflows:
   version: 2
   build:
     jobs:
-      - sanity:
-          filters:
-            tags:
-              only: /.*/
-      - build:
-          requires:
-            - sanity
-          filters:
-            tags:
-              only: /.*/
+    - build:
+        filters:
+          tags:
+            only: /.*/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+[![CircleCI][circleci-badge]][circleci-link]
+[![Docker Hub][docker-badge]][docker-link]
+
 # Apollo CI Base Image
 
 This repository holds the Dockerfile used in Apollo CircleCI builds.
+
+[circleci-badge]: https://circleci.com/gh/stackrox/rox-ci-image.svg?&style=shield&circle-token=f9c93b8793b8d77af175d0f34a200fe7261212d2
+[circleci-link]:  https://circleci.com/gh/stackrox/workflows/rox-ci-image/tree/master
+[docker-badge]:   https://img.shields.io/badge/docker-hub-blue.svg
+[docker-link]:    https://hub.docker.com/r/stackrox/apollo-ci/tags/


### PR DESCRIPTION
- Removed sanity stage from CircleCI build. Things are very stable in this area, no longer needed.
- Push snapshot images from non-master/non-tag builds. Tag images built on a PR with a snapshot prefix.
- CircleCI and Docker Hub badges for the readme. I hate having to search for the workflow or repo links...