### PR TITLE
move-yarn-version-back-to-Ubuntu-supported

### DIFF
--- a/images/Dockerfile.rox
+++ b/images/Dockerfile.rox
@@ -43,7 +43,7 @@ RUN set -ex \
       unzip \
       # used in scanner
       postgresql-client-12 \
-      yarn=1.10.1-1 \
+      yarn=1.17.3 \
       `# gcloud SDK dependencies:` \
       python2.7-minimal \
       libpython-stdlib \


### PR DESCRIPTION
Looks like the latest version is not available for the distro we are using
> E: Version '1.19.2' for 'yarn' was not found

From an article this past Sept 2019.
> At the time of writing this article, the latest version of Yarn is version 1.17.3
https://linuxize.com/post/how-to-install-yarn-on-ubuntu-18-04/