### PR TITLE
Add libgbm for Cypress 5 and use Node.js LTS

### DIFF
--- a/images/Dockerfile.rox
+++ b/images/Dockerfile.rox
@@ -23,7 +23,7 @@ RUN set -ex \
       # Required in scanner
       rpm \
       lsb-core \
- && wget --no-verbose -O - https://deb.nodesource.com/setup_lts.x| bash - \
+ && wget --no-verbose -O - https://deb.nodesource.com/setup_lts.x | bash - \
  && wget --no-verbose -O - https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
  && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
  && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \


### PR DESCRIPTION
 - Cypress 5 now requires libgbm [here](https://docs.cypress.io/guides/guides/continuous-integration.html#Dependencies).
 - Use Node.js LTS instead of old 10.x LTS. It's somewhat risky, as it'll bump the Node.js whenever major LTS is released by Node... But honestly, it's more likely that we'll be stuck with old version rather than major LTS release will break something for us, as it always happens when everyone already supports that major version of Node.js.

~Can you advise me the next steps to publish the image? Build locally, and publish from my machine? What's the versioning model?~

~I'm happy to update the README to include the instructions on publishing, but I'd really appreciate some "commands for dummy" that I can do, as it's been months and months since I did it myself. And then after doing it I can open another PR with README update.~

*Update 1*: Nevermind, turned out we have CircleCI builds for everything!

*Update 2*: Aha, I still need to push a tag and choose a version... Oh well, README can be improved.