### PR TITLE
Reload bash env only when changed

### DIFF
--- a/images/static-contents/etc/bash.env
+++ b/images/static-contents/etc/bash.env
@@ -23,8 +23,13 @@ cci-export() {
 }
 
 if [ -f "${REAL_BASH_ENV:-}" ]; then
+  checksum="$(md5sum "${REAL_BASH_ENV}" | awk '{print$1}')"
+  if [[ "${REAL_BASH_ENV_LOADED:-}" != "$checksum" ]]; then
 	. "${REAL_BASH_ENV}"
+	export REAL_BASH_ENV_LOADED="$checksum"
+  fi
 fi
+
 if [ -n "${REAL_BASH_ENV:-}" ]; then
 	export BASH_ENV="$REAL_BASH_ENV"
 fi


### PR DESCRIPTION
The current setup makes it impossible to override variables that were set via `cci-export` when invoking scripts. E.g., when running `GOTAGS=foobar scripts/go-test.sh` in a CI run using the `ci-use-release-build` label (which causes `cci-export GOTAGS release` to be executed), the `$GOTAGS` as seen by `go-test.sh` are `release`.

Change the behavior to only load the mutable bash.env file once in each session, or when its contents change.