### PR TITLE
Update aws cli version

### DIFF
--- a/images/Dockerfile.rox
+++ b/images/Dockerfile.rox
@@ -180,7 +180,9 @@ RUN set -ex \
 
 # Install aws cli
 RUN set -ex \
- && pip3 install awscli==1.17.16 \
+ && curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.0.30.zip" -o "awscliv2.zip" \
+ && unzip awscliv2.zip \
+ && sudo ./aws/install \
  && aws --version
 
 # Install anchore cli


### PR DESCRIPTION
Updating the version of aws cli installed in the image. This will be used later to connect to our ECR registry and push release images.

See [ROX-5708](https://stack-rox.atlassian.net/browse/ROX-5708)