### PR TITLE
Update docker cli to be able to use docker buildkit goodness

### DIFF
--- a/images/Dockerfile.rox
+++ b/images/Dockerfile.rox
@@ -98,7 +98,7 @@ RUN set -ex \
  && echo 'circleci ALL=NOPASSWD: ALL' > /etc/sudoers.d/50-circleci
 
 # Install docker binary
-ARG DOCKER_VERSION=18.06.1-ce
+ARG DOCKER_VERSION=20.10.6
 RUN set -ex \
  && DOCKER_URL="https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz" \
  && echo Docker URL: $DOCKER_URL \


### PR DESCRIPTION
## Description

While working on https://github.com/stackrox/rox/pull/8219 I saw how awesome it is to use Docker buildkit features for making host's SSH keys available in `Dockerfile` build. This feature isn't available in docker version 18.06.1-ce that was previously provisioned in `rox`/`apollo-ci` image therefore bumping it to the most recent available - 20.10.6.

**Note:** a more official way to install `docker` cli is by using `apt` here <https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository>. I'm not sure if I should switch to that or leave it as-is. Your opinion needed.

## Testing done

Hoping that CI pipeline for StackRox should catch any issues or regressions https://github.com/stackrox/rox/pull/8234