### PR TITLE
CI: Determine the authoritative source of OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,7 +2,9 @@ approvers:
     connorgorman
     gavin-stackrox
     sbostick
+    viswajithiii
 reviewers:
     connorgorman
     gavin-stackrox
     sbostick
+    viswajithiii


### PR DESCRIPTION
Is it stackrox/rox-ci-image or openshift/releases. i.e. I expect this change to update the OWNERS files in the latter. 🤞 