### PR TITLE
openshift CI: add viswa

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,10 +1,10 @@
 approvers:
-    connorgorman
-    gavin-stackrox
-    sbostick
-    viswajithiii
+- connorgorman
+- gavin-stackrox
+- sbostick
+- viswajithiii
 reviewers:
-    connorgorman
-    gavin-stackrox
-    sbostick
-    viswajithiii
+- connorgorman
+- gavin-stackrox
+- sbostick
+- viswajithiii


### PR DESCRIPTION
Another test to find the authoritative source of OWNERS in openshift/release.