### PR TITLE
RS-353: Install bats-support, bats-assert. Pin version of tap-junit

### DIFF
--- a/images/Dockerfile.rox
+++ b/images/Dockerfile.rox
@@ -83,7 +83,7 @@ RUN set -ex \
 
 # Install bats
 RUN set -ex \
-  && npm install -g bats@1.5.0 bats-support@0.3.0 bats-assert@2.0.0 tap-junit@5.0.1 \
+  && npm install -g bats@1.2.0 bats-support@0.3.0 bats-assert@2.0.0 tap-junit@5.0.1 \
   && bats -v
 
 # Install jq


### PR DESCRIPTION
I would like to leverage Bats and its support packages in the contexts of https://github.com/stackrox/stackrox/pull/23, thus I would like to:
- ~~Update bats from v1.2.0 to v1.5.0 to be able to use such parameters as: `--print-output-on-failure` `--verbose-run`, or `--show-output-of-passing-tests` (they were all added in v1.5.0)~~ need to skip this for now - see further comments in this PR.
- Install `bats-assert` and `bats-support` to be able to write compact and easy to read assertions in Bats tests.

I have also pinned the version of `tap-junit` (installed in the same line), because `hadolint` suggested it and I wanted to follow this suggestion.