### PR TITLE
Update repo ref from rox to stackrox for automatically opened PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,13 +65,13 @@ jobs:
         at: /tmp
 
     - run:
-        name: Clone rox repo
+        name: Clone stackrox repo
         command: |
-          git clone git@github.com:stackrox/rox.git /tmp/rox
+          git clone git@github.com:stackrox/stackrox.git /tmp/stackrox
 
     - run:
-        name: Create commit in rox that updates the base image
-        working_directory: /tmp/rox
+        name: Create commit in stackrox that updates the base image
+        working_directory: /tmp/stackrox
         command: |
           pushed_image="$(cat /tmp/pushed_image)"
           [[ -n "${pushed_image}" ]]

--- a/.circleci/create_update_pr_rox.sh
+++ b/.circleci/create_update_pr_rox.sh
@@ -24,7 +24,7 @@ status_code="$(curl -sS \
   -o "$pr_response_file" \
   -X POST \
   -H "Authorization: token ${GITHUB_TOKEN}" \
-  'https://api.github.com/repos/stackrox/rox/pulls' \
+  'https://api.github.com/repos/stackrox/stackrox/pulls' \
   -d"{
   \"title\": \"Update rox-ci-image\",
   \"body\": $(jq -sR <<<"$message"),
@@ -46,7 +46,7 @@ if [[ "${status_code}" -eq 201 ]]; then
   curl -sS --fail \
  -X POST \
  -H "Authorization: token ${GITHUB_TOKEN}" \
- "https://api.github.com/repos/stackrox/rox/issues/${pr_number}/assignees" \
+ "https://api.github.com/repos/stackrox/stackrox/issues/${pr_number}/assignees" \
  -d"{
     \"assignees\": [\"${CIRCLE_USERNAME}\"]
   }"


### PR DESCRIPTION
I have noticed, that my other PR (#94) has opened an image-bump PR in the `rox` repo (https://github.com/stackrox/rox/pull/9967).

In this PR, I update the references to the `rox` repo so that they point to the new `stackrox` repository instead.