### PR TITLE
Fix: `env-check` image reference on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,11 @@ jobs:
           name: Run unit tests for circleci-tools using the built image
           command: |
             export TAG="$(git describe --tags --abbrev=10)"
-            export IMAGE="quay.io/rhacs-eng/apollo-ci:snapshot-env-check-$TAG"
+            tag_prefix="snapshot-env-check-"
+            if [[ $CIRCLE_BRANCH = master || -n $CIRCLE_TAG ]]; then
+              tag_prefix="env-check-"
+            fi
+            export IMAGE="quay.io/rhacs-eng/apollo-ci:${tag_prefix}${TAG}"
             docker pull "$IMAGE"
             images/circleci-tools/test/test.bats
 
@@ -134,7 +138,11 @@ jobs:
           name: Check build output using the built image
           command: |
             export TAG="$(git describe --tags --abbrev=10)"
-            export IMAGE="quay.io/rhacs-eng/apollo-ci:snapshot-env-check-$TAG"
+            tag_prefix="snapshot-env-check-"
+            if [[ $CIRCLE_BRANCH = master || -n $CIRCLE_TAG ]]; then
+              tag_prefix="env-check-"
+            fi
+            export IMAGE="quay.io/rhacs-eng/apollo-ci:${tag_prefix}${TAG}"
             export CIRCLECI_TOKEN="$CIRCLE_TOKEN_ROXBOT"
             docker pull "$IMAGE"
 


### PR DESCRIPTION
Apparently the CI steps `unit-test-env` and `check-env-for-sensitive-values` expect an image in form of `quay.io/rhacs-eng/apollo-ci:snapshot-env-check-<version>-<git_sha>`. However, on `master` (or tag), the images do not contain the `snapshot-` prefix currently.

Exemplary failures on `master`: 
- https://app.circleci.com/pipelines/github/stackrox/rox-ci-image/410/workflows/bd839d22-c870-4f26-9098-9505a0b85e33/jobs/1437
- https://app.circleci.com/pipelines/github/stackrox/rox-ci-image/405/workflows/bb707b77-9d80-4252-a898-0b7c4d01e2e0

This PR adds an if-clause to use a different image reference on master and tags, so that the respective CI-builds can be reported as green.

