### PR TITLE
Support cci-export() in non Circle CI environments

### DIFF
--- a/images/circleci.Dockerfile
+++ b/images/circleci.Dockerfile
@@ -7,6 +7,9 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ENV GOCACHE="/linux-gocache"
 
+# Circle CI manages its own BASH_ENV.
+ENV BASH_ENV=
+
 RUN set -ex && \
     yum update -y && \
     yum install -y \
@@ -17,8 +20,8 @@ RUN set -ex && \
     groupadd --gid 3434 circleci && \
     useradd --uid 3434 --gid circleci --shell /bin/bash --create-home circleci && \
     echo 'circleci ALL=NOPASSWD: ALL' > /etc/sudoers.d/50-circleci && \
-    chown -R circleci:circleci "$GOPATH"  && \
-    mkdir -p "$GOCACHE"  && \
+    chown -R circleci:circleci "$GOPATH" && \
+    mkdir -p "$GOCACHE" && \
     chown -R circleci:circleci "$GOCACHE"
 
 USER circleci

--- a/images/stackrox-test.Dockerfile
+++ b/images/stackrox-test.Dockerfile
@@ -19,8 +19,8 @@ RUN set -ex \
   && find /static-tmp -type f -print0 | \
     xargs -0 -I '{}' -n1 bash -c 'dir="$(dirname "${1}")"; new_dir="${dir#/static-tmp}"; mkdir -p "${new_dir}"; cp "${1}" "${new_dir}";' -- {} \
   && rm -r /static-tmp
-# Circle CI will override this to pass an environment for bash. Other
-# environments need this as a foundation for cci-export().
+# Circle CI uses BASH_ENV to pass an environment for bash. Other environments need
+# an initial BASH_ENV as a foundation for cci-export().
 ENV BASH_ENV /etc/initial-bash.env
 
 # Install all the packages

--- a/images/static-contents/etc/initial-bash.env
+++ b/images/static-contents/etc/initial-bash.env
@@ -1,2 +1,2 @@
-# Circle CI will override this to pass an environment for bash. Other
-# environments need this as a foundation for cci-export().
+# Circle CI uses BASH_ENV to pass an environment for bash. Other environments need
+# an initial BASH_ENV as a foundation for cci-export().


### PR DESCRIPTION
## Testing

- [x] Ensure that the auto PR CI runs OK with this change i.e. Circle CI can override the initial BASH_ENV to pass its env values.
- [x] `test-cci-export` passes