### PR TITLE
PostgreSQL 12

### DIFF
--- a/images/stackrox-test.Dockerfile
+++ b/images/stackrox-test.Dockerfile
@@ -34,6 +34,7 @@ RUN yum update -y && \
         jq \
         kubectl \
         lsof \
+        @postgresql:12 \
         unzip \
         xz \
         zip \
@@ -42,9 +43,6 @@ RUN yum update -y && \
         && \
     yum clean all && \
     rm -rf /var/cache/yum
-
-# Install postgresql
-RUN yum module install -y postgresql:12
 
 # Install bats
 RUN set -ex \


### PR DESCRIPTION
Scanner uses PostgreSQL 12, so we need to ensure we have that version. It is currently on 10