### PR TITLE
ROX-10959: Add scanner-build image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,8 +76,8 @@ commands:
               # If the image parameter was originally quoted, we need to close the quote
               sed -r -i "s@\"(.*)/apollo-ci:${tag} # TODO@\"\1/apollo-ci:${tag}\" # TODO@g" .circleci/config.yml
 
-              if [[ "$flavor" == "stackrox-build" ]] && [[ "<< parameters.repo >>" == "stackrox" ||
-                    "$flavor" == "scanner-build" ]] && [[ "<< parameters.repo >>" == "scanner" ]]; then
+              if [[ ("$flavor" == "stackrox-build" && "<< parameters.repo >>" == "stackrox") ||
+                    ("$flavor" == "scanner-build" && "<< parameters.repo >>" == "scanner") ]]; then
                 echo "${tag} ${todo}" > BUILD_IMAGE_VERSION
                 git add BUILD_IMAGE_VERSION
               fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,8 @@ commands:
               # If the image parameter was originally quoted, we need to close the quote
               sed -r -i "s@\"(.*)/apollo-ci:${tag} # TODO@\"\1/apollo-ci:${tag}\" # TODO@g" .circleci/config.yml
 
-              if [[ "$flavor" == "stackrox-build" ]] && [[ "<< parameters.repo >>" == "stackrox" ]]; then
+              if [[ "$flavor" == "stackrox-build" ]] && [[ "<< parameters.repo >>" == "stackrox" ||
+                    "$flavor" == "scanner-build" ]] && [[ "<< parameters.repo >>" == "scanner" ]]; then
                 echo "${tag} ${todo}" > BUILD_IMAGE_VERSION
                 git add BUILD_IMAGE_VERSION
               fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -303,6 +303,15 @@ jobs:
       - check-image:
           image-flavor: "collector"
 
+  build-and-push-scanner-build:
+    <<: *defaults
+    steps:
+      - build-and-push-image:
+          dockerfile-path: images/scanner-build.Dockerfile
+          image-flavor: "scanner-build"
+      - check-image:
+          image-flavor: "scanner-build"
+
   build-and-push-jenkins-plugin:
     <<: *defaults
     steps:
@@ -421,6 +430,15 @@ workflows:
             only: /.*/
         requires:
         - bats/run
+    - build-and-push-scanner-build:
+        context: &buildPushCheckContext
+          - quay-rhacs-eng-readwrite
+          - quay-stackrox-io-readwrite
+          - stackrox-ci-instance
+          - docker-io-pull
+        filters:
+          tags:
+            only: /.*/
     - build-and-push-jenkins-plugin:
         context:
           *buildPushCheckContext

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,6 +150,7 @@ commands:
             if [[ "<< parameters.image-flavor >>" == "stackrox-build" || "<< parameters.image-flavor >>" == "scanner-build" ]]; then
               for i in {1..5}; do
                 docker login -u "$QUAY_STACKROX_IO_RW_USERNAME" -p "$QUAY_STACKROX_IO_RW_PASSWORD" quay.io
+                docker tag "${IMAGE}" "quay.io/stackrox-io/apollo-ci:${TAG}"
                 docker push "quay.io/stackrox-io/apollo-ci:${TAG}" && break || sleep 15
               done
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -467,6 +467,7 @@ workflows:
           branches:
             ignore: master
         requires:
+        - build-and-push-scanner-build
         - build-and-push-stackrox-test-cci
     - create-or-update-jenkins-plugin-repo-pr:
         filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ commands:
               docker push "quay.io/rhacs-eng/apollo-ci:${TAG}" && break || sleep 15
             done
 
-            if [[ "<< parameters.image-flavor >>" == "stackrox-build" ]]; then
+            if [[ "<< parameters.image-flavor >>" == "stackrox-build" || "<< parameters.image-flavor >>" == "scanner-build" ]]; then
               for i in {1..5}; do
                 docker login -u "$QUAY_STACKROX_IO_RW_USERNAME" -p "$QUAY_STACKROX_IO_RW_PASSWORD" quay.io
                 docker push "quay.io/stackrox-io/apollo-ci:${TAG}" && break || sleep 15

--- a/images/scanner-build.Dockerfile
+++ b/images/scanner-build.Dockerfile
@@ -6,7 +6,7 @@ FROM quay.io/centos/centos:${CENTOS_TAG}
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN dnf update -y && \
-    dnf install -y dnf-plugins-core epel-release && \
+    dnf install -y dnf-plugins-core epel-release wget && \
     dnf -y groupinstall "Development Tools" && \
     dnf clean all && \
     rm -rf /var/cache/dnf /var/cache/yum

--- a/images/scanner-build.Dockerfile
+++ b/images/scanner-build.Dockerfile
@@ -1,0 +1,26 @@
+# Provides the tooling required to run Scanner dockerized build targets.
+
+ARG CENTOS_TAG
+FROM quay.io/centos/centos:${CENTOS_TAG}
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN dnf update -y && \
+    dnf install -y dnf-plugins-core epel-release && \
+    dnf -y groupinstall "Development Tools" && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf /var/cache/yum
+
+ARG GOLANG_VERSION=1.17.2
+ARG GOLANG_SHA256=f242a9db6a0ad1846de7b6d94d507915d14062660616a61ef7c808a76e4f1676
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+RUN url="https://dl.google.com/go/go${GOLANG_VERSION}.linux-amd64.tar.gz" && \
+    wget --no-verbose -O go.tgz "$url" && \
+    echo "${GOLANG_SHA256} *go.tgz" | sha256sum -c - && \
+    tar -C /usr/local -xzf go.tgz && \
+    rm go.tgz && \
+    mkdir -p "$GOPATH/src" "$GOPATH/bin" && \
+    chmod -R 777 "$GOPATH"
+
+WORKDIR /go/src/github.com/stackrox/scanner


### PR DESCRIPTION
Based on https://github.com/stackrox/rox-ci-image/blob/master/images/stackrox-build.Dockerfile and https://github.com/stackrox/scanner/blob/2.24.0/build/Dockerfile

Similar to the stackrox repo, we should update the scanner repo to use a build image form here instead of the current one embedded in the repo based on `centos:8`. I considered just reusing the `stackrox-build` image, but I ran into issues using it (something about the `libsnappy` shared library being missing. My guess is that issue is related to the fact the `stackrox-build` image uses CGO? I really don't have a better guess than that).