### PR TITLE
Remove Anchore references

### DIFF
--- a/images/circleci-tools/constants.js
+++ b/images/circleci-tools/constants.js
@@ -4,7 +4,6 @@ export const V2_API_BASE = "https://circleci.com/api/v2";
 
 export const SKIP_KEYS = [
     "rvm_prefix",
-    "ANCHORE_USERNAME",
     "CI",
     "CIRCLECI",
     "DBUS_SESSION_BUS_ADDRESS",

--- a/images/stackrox-test.Dockerfile
+++ b/images/stackrox-test.Dockerfile
@@ -103,11 +103,6 @@ RUN set -ex \
  && rm -rf aws \
  && aws --version
 
-# Install anchore cli
-RUN set -ex \
- && pip3 install anchorecli==0.9.3 \
- && LC_ALL=C.UTF-8 anchore-cli --version
-
 # Install yq v4.16.2
 RUN set -ex \
   && wget --no-verbose "https://github.com/mikefarah/yq/releases/download/v4.16.2/yq_linux_amd64" \


### PR DESCRIPTION
We no longer use Anchore in CI, so might as well remove it from the images.