### PR TITLE
Add docker to the collector CI image

### DIFF
--- a/images/collector.Dockerfile
+++ b/images/collector.Dockerfile
@@ -33,6 +33,9 @@ RUN yum update -y && \
 # Symlink python to python3
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
+# Install pip
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py
+
 ARG GOLANG_VERSION=1.16.15
 ARG GOLANG_SHA256=77c782a633186d78c384f972fb113a43c24be0234c42fef22c2d8c4c4c8e7475
 ENV GOPATH /go

--- a/images/collector.Dockerfile
+++ b/images/collector.Dockerfile
@@ -12,6 +12,7 @@ RUN set -ex \
 RUN yum update -y && \
     yum install -y epel-release dnf-plugins-core && \
     yum config-manager --set-enabled powertools && \
+    yum config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo && \
     yum -y groupinstall "Development Tools" && \
     yum install -y \
         clang-tools-extra \
@@ -20,6 +21,10 @@ RUN yum update -y && \
         jq \
         python38 \
         wget \
+        docker-ce \
+        docker-ce-cli \
+        docker-ce-rootless-extras \
+        docker-scan-plugin \
         && \
     yum upgrade -y && \
     yum clean all && \
@@ -77,4 +82,3 @@ RUN \
 	mv /bin/bash-wrapper /bin/bash
 
 USER circleci
-


### PR DESCRIPTION
After updating the collector CI image to use centos stream8 as its base, the docker command was no longer available which lead to some CI jobs to fail. This PR installs the same docker components found in the original cimg/go image.