### PR TITLE
Update gcloud auth plugin

### DIFF
--- a/.circleci/changes_affect.sh
+++ b/.circleci/changes_affect.sh
@@ -34,8 +34,7 @@ affects_collector() {
 }
 
 affects_scanner() {
-  [[ " $* " =~ [[:space:]]images/rocksdb.Dockerfile[[:space:]] ]] \
-    || [[ " $* " =~ [[:space:]]images/scanner-build.Dockerfile[[:space:]] ]] \
+  [[ " $* " =~ [[:space:]]images/scanner-build.Dockerfile[[:space:]] ]] \
     || [[ " $* " =~ [[:space:]]images/scanner-test.Dockerfile[[:space:]] ]] \
     || [[ " $* " =~ [[:space:]]images/circleci.Dockerfile[[:space:]] ]] \
     || [[ " $* " =~ [[:space:]]images/static-contents/etc/yum.repos.d/google-cloud-sdk.repo[[:space:]] ]] \

--- a/.circleci/changes_affect.sh
+++ b/.circleci/changes_affect.sh
@@ -34,7 +34,12 @@ affects_collector() {
 }
 
 affects_scanner() {
-  affects_stackrox "$*"
+  [[ " $* " =~ [[:space:]]images/rocksdb.Dockerfile[[:space:]] ]] \
+    || [[ " $* " =~ [[:space:]]images/scanner-build.Dockerfile[[:space:]] ]] \
+    || [[ " $* " =~ [[:space:]]images/scanner-test.Dockerfile[[:space:]] ]] \
+    || [[ " $* " =~ [[:space:]]images/circleci.Dockerfile[[:space:]] ]] \
+    || [[ " $* " =~ [[:space:]]images/static-contents/etc/yum.repos.d/google-cloud-sdk.repo[[:space:]] ]] \
+    || [[ " $* " =~ [[:space:]]images/static-contents/scripts/create_update_pr.sh[[:space:]] ]]
 }
 
 affects_stackrox() {

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ commands:
 
             git config user.email "roxbot@stackrox.com"
             git config user.name "RoxBot"
-            branch_name="roxbot/update-ci-image-from-${CIRCLE_PULL_REQUEST##*/}"
+            branch_name="stackrox-update-ci-image-from-${CIRCLE_PULL_REQUEST##*/}"
             if git fetch --quiet origin "${branch_name}"; then
               git checkout "${branch_name}"
               git pull --quiet --set-upstream origin "${branch_name}"

--- a/images/scanner-test.Dockerfile
+++ b/images/scanner-test.Dockerfile
@@ -29,6 +29,7 @@ RUN dnf update -y && \
         gcc \
         gcc-c++ \
         google-cloud-sdk \
+        google-cloud-sdk-gke-gcloud-auth-plugin \
         jq \
         kubectl \
         lsof \
@@ -42,6 +43,10 @@ RUN dnf update -y && \
         && \
     dnf clean all && \
     rm -rf /var/cache/dnf /var/cache/yum
+
+# Use updated auth plugin for GCP
+ENV USE_GKE_GCLOUD_AUTH_PLUGIN=True
+RUN gke-gcloud-auth-plugin --version
 
 # Install docker binary
 ARG DOCKER_VERSION=20.10.6

--- a/images/stackrox-test.Dockerfile
+++ b/images/stackrox-test.Dockerfile
@@ -49,6 +49,12 @@ RUN dnf update -y && \
     dnf clean all && \
     rm -rf /var/cache/dnf /var/cache/yum
 
+# Get updated auth plugin for GCP
+ENV USE_GKE_GCLOUD_AUTH_PLUGIN=True
+RUN gcloud components install gke-gcloud-auth-plugin && \
+    gke-gcloud-auth-plugin --version && \
+    gcloud components update
+
 # Update PATH for Postgres14
 ENV PATH=$PATH:/usr/pgsql-14/bin
 

--- a/images/stackrox-test.Dockerfile
+++ b/images/stackrox-test.Dockerfile
@@ -33,6 +33,7 @@ RUN dnf update -y && \
         gcc \
         gcc-c++ \
         google-cloud-sdk \
+        google-cloud-sdk-gke-gcloud-auth-plugin \
         java-1.8.0-openjdk-devel \
         jq \
         kubectl \
@@ -49,11 +50,9 @@ RUN dnf update -y && \
     dnf clean all && \
     rm -rf /var/cache/dnf /var/cache/yum
 
-# Get updated auth plugin for GCP
+# Use updated auth plugin for GCP
 ENV USE_GKE_GCLOUD_AUTH_PLUGIN=True
-RUN gcloud components install gke-gcloud-auth-plugin && \
-    gke-gcloud-auth-plugin --version && \
-    gcloud components update
+RUN gke-gcloud-auth-plugin --version
 
 # Update PATH for Postgres14
 ENV PATH=$PATH:/usr/pgsql-14/bin


### PR DESCRIPTION
This is to handle the plugin change that will be required at v1.25.
```
W0609 20:41:12.637017   29729 gcp.go:120] WARNING: the gcp auth plugin is deprecated in v1.22+, unavailable in v1.25+; use gcloud instead.
To learn more, consult https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
```