### PR TITLE
Upgrade AWS CLI

### DIFF
--- a/images/stackrox-test.Dockerfile
+++ b/images/stackrox-test.Dockerfile
@@ -108,12 +108,8 @@ RUN set -ex \
 
 # Install aws cli
 RUN set -ex \
- && wget --no-verbose -O "awscliv2.zip" "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.0.30.zip" \
- && unzip awscliv2.zip \
- && ./aws/install \
- && rm awscliv2.zip \
- && rm -rf aws \
- && aws --version
+  && pip3 --no-cache-dir install awscli==1.25.4 \
+  && aws --version
 
 # Install yq v4.16.2
 RUN set -ex \

--- a/images/stackrox-test.Dockerfile
+++ b/images/stackrox-test.Dockerfile
@@ -108,8 +108,12 @@ RUN set -ex \
 
 # Install aws cli
 RUN set -ex \
-  && pip3 --no-cache-dir install awscli==1.25.4 \
-  && aws --version
+ && wget --no-verbose -O "awscliv2.zip" "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.7.17.zip" \
+ && unzip awscliv2.zip \
+ && ./aws/install \
+ && rm awscliv2.zip \
+ && rm -rf aws \
+ && aws --version
 
 # Install yq v4.16.2
 RUN set -ex \


### PR DESCRIPTION
Earlier versions have an [issue](https://github.com/aws/aws-cli/pull/6476) with v1.24 kubectl.

## Testing

An openshift/release PR was used to test this image as a build root for stackrox and automation-flavors.
- https://github.com/openshift/release/pull/30842
- Passes EKS test: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/30842/rehearse-30842-pull-ci-stackrox-automation-flavors-gavin-OSCI-onboard-EKS-test-eks/1552360140773003264
- Build output: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_release/30842/rehearse-30842-pull-ci-stackrox-automation-flavors-gavin-OSCI-onboard-EKS-test-eks/1552360140773003264/artifacts/test-eks/test/build-log.txt
- Passed most GKE tests but will reach rehearsal job limit.

## Release

This change will be tagged 0.3.34 once merged.