### PR TITLE
Downgrade scanner builder to stream8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,3 +68,18 @@ collector-test-image:
 	$(DOCKER) build \
 		-f images/collector.Dockerfile \
 		images/
+
+.PHONY: scanner-test-image scanner-build-image
+
+scanner-test-image:
+	$(DOCKER) build \
+	    --build-arg BASE_TAG=$(shell .circleci/get_tag.sh "scanner-build") \
+	    -t quay.io/rhacs-eng/apollo-ci:$(shell .circleci/get_tag.sh "scanner-test") \
+	    -f images/scanner-test.Dockerfile \
+	    images/
+
+scanner-build-image:
+	$(DOCKER) build \
+	    -t quay.io/rhacs-eng/apollo-ci:$(shell .circleci/get_tag.sh "scanner-build") \
+	    -f images/scanner-build.Dockerfile \
+	    images/

--- a/images/scanner-build.Dockerfile
+++ b/images/scanner-build.Dockerfile
@@ -1,6 +1,6 @@
 # Provides the tooling required to run Scanner dockerized build targets.
 
-FROM quay.io/centos/centos:stream9
+FROM quay.io/centos/centos:stream8
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/images/static-contents-scanner/etc/yum.repos.d/google-cloud-sdk.repo
+++ b/images/static-contents-scanner/etc/yum.repos.d/google-cloud-sdk.repo
@@ -1,8 +1,0 @@
-[google-cloud-sdk]
-name=Google Cloud SDK
-baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el9-x86_64
-enabled=1
-gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
-       https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg


### PR DESCRIPTION
Rollback Scanner to UBI8.

The original bump to UBI9 was done to onboard a new `rpm` version that now is not necessary since `ubi8/ubi-minimal:8.6` ships rpm 4.14.3 which has SQLite backported.

## Tests 

Local tests using the new build image.
