### PR TITLE
Do not set RocksDB library link directives via CGO_LDFLAGS env

### DIFF
--- a/images/stackrox-build.Dockerfile
+++ b/images/stackrox-build.Dockerfile
@@ -68,7 +68,7 @@ COPY --from=builder /tmp/rocksdb/include /lib/rocksdb/include
 COPY --from=builder /tmp/rocksdb/ldb /usr/local/bin/ldb
 
 ENV CGO_CFLAGS="-I/lib/rocksdb/include"
-ENV CGO_LDFLAGS="-L/lib/rocksdb -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy -llz4 -lzstd"
+ENV CGO_LDFLAGS="-L/lib/rocksdb"
 ENV CGO_ENABLED=1
 
 WORKDIR /go/src/github.com/stackrox/rox


### PR DESCRIPTION
These will already be set in the Go source via `#cgo` pragma directives. Specifying those in a container `ENV` OTOH causes _all_ CGo-enabled binaries to be linked against them, which is not desired.
