### PR TITLE
inclusive language: Rename 'master' branch to 'main'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,9 +13,6 @@ commands:
       repo:
         description: Name of the repo where the PR should be opened.
         type: string
-      repo-main-branch:
-        description: Name of the main branch of the repo.
-        type: string
       labels:
         description: Space separated list of PR labels to add.
         type: string
@@ -41,6 +38,12 @@ commands:
             fi
 
             pushd "/tmp/<< parameters.repo >>"
+            
+            main_branch="$(git symbolic-ref --short HEAD)"
+            [[ -n "$main_branch" ]] || {
+              echo >&2 "Could not determine main branch of repo github.com/stackrox/<< parameters.repo >>.git"
+              exit 1
+            }
 
             git config user.email "roxbot@stackrox.com"
             git config user.name "RoxBot"
@@ -68,7 +71,7 @@ commands:
               .circleci/create_update_pr.sh \
                 "${branch_name}" \
                 "<< parameters.repo >>" \
-                "<< parameters.repo_main_branch >>" \
+                "${main_branch}" \
                 "Update apollo-ci image" \
                 "Bump version of apollo-ci image used in CircleCI" \
                 "<< parameters.labels >>"
@@ -294,7 +297,6 @@ jobs:
     steps:
       - open-test-pr:
           repo: stackrox
-          repo-main-branch: master
           labels: "ci-upgrade-tests"
           image-flavors: "stackrox-build,stackrox-test-cci,stackrox-test"
 
@@ -303,7 +305,6 @@ jobs:
     steps:
       - open-test-pr:
           repo: scanner
-          repo-main-branch: master
           labels: "generate-dumps-on-pr"
           image-flavors: "scanner-build,scanner-test-cci,scanner-test"
 
@@ -312,7 +313,6 @@ jobs:
     steps:
       - open-test-pr:
           repo: collector
-          repo-main-branch: master
           image-flavors: "collector"
 
   create-or-update-jenkins-plugin-repo-pr:
@@ -320,7 +320,6 @@ jobs:
     steps:
       - open-test-pr:
           repo: jenkins-plugin
-          repo-main-branch: master
           image-flavors: "jenkins-plugin"
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,9 @@ commands:
       repo:
         description: Name of the repo where the PR should be opened.
         type: string
+      repo-main-branch:
+        description: Name of the main branch of the repo.
+        type: string
       labels:
         description: Space separated list of PR labels to add.
         type: string
@@ -65,6 +68,7 @@ commands:
               .circleci/create_update_pr.sh \
                 "${branch_name}" \
                 "<< parameters.repo >>" \
+                "<< parameters.repo_main_branch >>" \
                 "Update apollo-ci image" \
                 "Bump version of apollo-ci image used in CircleCI" \
                 "<< parameters.labels >>"
@@ -290,6 +294,7 @@ jobs:
     steps:
       - open-test-pr:
           repo: stackrox
+          repo-main-branch: master
           labels: "ci-upgrade-tests"
           image-flavors: "stackrox-build,stackrox-test-cci,stackrox-test"
 
@@ -298,6 +303,7 @@ jobs:
     steps:
       - open-test-pr:
           repo: scanner
+          repo-main-branch: master
           labels: "generate-dumps-on-pr"
           image-flavors: "scanner-build,scanner-test-cci,scanner-test"
 
@@ -306,6 +312,7 @@ jobs:
     steps:
       - open-test-pr:
           repo: collector
+          repo-main-branch: master
           image-flavors: "collector"
 
   create-or-update-jenkins-plugin-repo-pr:
@@ -313,6 +320,7 @@ jobs:
     steps:
       - open-test-pr:
           repo: jenkins-plugin
+          repo-main-branch: master
           image-flavors: "jenkins-plugin"
 
 workflows:
@@ -413,26 +421,34 @@ workflows:
     - create-or-update-collector-repo-pr:
         filters:
           branches:
-            ignore: master
+            ignore:
+            - master
+            - main
         requires:
         - build-and-push-collector
     - create-or-update-stackrox-repo-pr:
         filters:
           branches:
-            ignore: master
+            ignore:
+            - master
+            - main
         requires:
         - build-and-push-stackrox-build
         - build-and-push-stackrox-test-cci
     - create-or-update-scanner-repo-pr:
         filters:
           branches:
-            ignore: master
+            ignore:
+            - master
+            - main
         requires:
         - build-and-push-scanner-build
         - build-and-push-scanner-test-cci
     - create-or-update-jenkins-plugin-repo-pr:
         filters:
           branches:
-            ignore: master
+            ignore:
+            - master
+            - main
         requires:
         - build-and-push-jenkins-plugin

--- a/images/static-contents/scripts/create_update_pr.sh
+++ b/images/static-contents/scripts/create_update_pr.sh
@@ -157,7 +157,7 @@ create_pr_and_get_http_status() {
   local pr_description="This is an automated PR created from ${CIRCLE_PULL_REQUEST:-"'source unknown'"}.
   $pr_description_body"
   local payload
-  payload="$(printf '{"title": "%s", "body": %s, "head": "%s", "base": "master"}' "$pr_title" "$(jq -sR <<<"$pr_description")" "$branch_name")"
+  payload="$(jq -nr '{"title": $title, "body": $body, "head": $head, "base": $base}' --arg title "$pr_title" --arg body "$pr_description" --arg head "$branch_name" --arg base "$repo_main_branch")"
   # warning: no --fail here - we accept code 422 as not-error
   github_curl \
     -X POST \


### PR DESCRIPTION
The repo is small enough that this change isn't likely to break anything.

Also change the PR creation script to not assume the default branch to be called `master` in the other repos.