### PR TITLE
Scanner test image: Add ps

### DIFF
--- a/images/scanner-test.Dockerfile
+++ b/images/scanner-test.Dockerfile
@@ -50,6 +50,7 @@ RUN dnf install -y \
         lz4 \
         openssl \
         postgresql${PG_MAJOR}-server \
+        procps-ng \
         python3 \
         unzip \
         xz \


### PR DESCRIPTION
ps can be useful when figuring out what is going on during test.
```
$ oc rsh e2e-tests-e2e-tests
Defaulting container name to test.
Use 'oc describe pod/e2e-tests-e2e-tests -n ci-op-i52dmpmm' to see all of the containers in this pod.
real-bash-4.4$ ps
real-bash: ps: command not found
```