### PR TITLE
Update java to 17

### DIFF
--- a/images/stackrox-test.Dockerfile
+++ b/images/stackrox-test.Dockerfile
@@ -34,7 +34,7 @@ RUN dnf update -y && \
         gcc-c++ \
         google-cloud-sdk \
         google-cloud-sdk-gke-gcloud-auth-plugin \
-        java-1.8.0-openjdk-devel \
+        java-17-openjdk-devel \
         kubectl \
         lsof \
         lz4 \


### PR DESCRIPTION
Although Java 8 is still have security support and openjdk will support it until 2026 it's not actively supported (ended 7 months ago
(31 Mar 2022)) and new libs use features from Java 11 (e.g. logback). This PR updates java to 17 LTS that will be actively supported until 2029. https://endoflife.date/java