### PR TITLE
Remove JRE 8

### DIFF
--- a/images/stackrox-test.Dockerfile
+++ b/images/stackrox-test.Dockerfile
@@ -34,7 +34,7 @@ RUN dnf update -y && \
         gcc-c++ \
         google-cloud-sdk \
         google-cloud-sdk-gke-gcloud-auth-plugin \
-        java-1.8.0-openjdk-devel \
+        java-17-openjdk-devel \
         kubectl \
         lsof \
         lz4 \
@@ -47,6 +47,7 @@ RUN dnf update -y && \
         # `# Cypress dependencies: (see https://docs.cypress.io/guides/guides/continuous-integration.html#Dependencies)` \
         xorg-x11-server-Xvfb gtk2-devel gtk3-devel libnotify-devel GConf2 nss libXScrnSaver alsa-lib \
         && \
+	dnf remove -y java-1.8.0-openjdk-headless && \
     dnf --disablerepo="*" --enablerepo="pgdg14" install -y postgresql14 postgresql14-server postgresql14-contrib && \
     dnf clean all && \
     rm -rf /var/cache/dnf /var/cache/yum

--- a/images/stackrox-test.Dockerfile
+++ b/images/stackrox-test.Dockerfile
@@ -34,7 +34,7 @@ RUN dnf update -y && \
         gcc-c++ \
         google-cloud-sdk \
         google-cloud-sdk-gke-gcloud-auth-plugin \
-        java-17-openjdk-devel \
+        java-1.8.0-openjdk-devel \
         kubectl \
         lsof \
         lz4 \


### PR DESCRIPTION
Fixes stackrox/rox-ci-image#173

Looks like jre 8 is installed by default causing issues when trying to use jdk as wrong java version is used.
```
 Could not find tools.jar. Please check that /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.322.b06-11.el8.x86_64/jre contains a valid JDK installation
```

This PR removes java 8 after installation java 17 so 17 will be the default and only java version.

Tested:
```sh
# docker run -it quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.54
[root@3c5aaa14f708 rox]# java -version
openjdk version "1.8.0_322"
OpenJDK Runtime Environment (build 1.8.0_322-b06)
OpenJDK 64-Bit Server VM (build 25.322-b06, mixed mode)
[root@3c5aaa14f708 rox]# dnf remove -y -q java-1.8.0-openjdk-headless

Removed:
  java-1.8.0-openjdk-headless-1:1.8.0.322.b06-11.el8.x86_64                               jna-4.5.1-5.el8.x86_64                              

[root@3c5aaa14f708 rox]# java -version
openjdk version "17.0.5" 2022-10-18 LTS
OpenJDK Runtime Environment (Red_Hat-17.0.5.0.8-2.el8) (build 17.0.5+8-LTS)
OpenJDK 64-Bit Server VM (Red_Hat-17.0.5.0.8-2.el8) (build 17.0.5+8-LTS, mixed mode, sharing)
```
