### PR TITLE
ROX-14352: Bump oc version.

### DIFF
--- a/images/scanner-test.Dockerfile
+++ b/images/scanner-test.Dockerfile
@@ -78,10 +78,11 @@ RUN set -ex \
 
 # oc
 RUN set -ex \
- && wget --no-verbose -O oc.tgz https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz \
- && tar -xf oc.tgz \
- && install openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit/oc /usr/local/bin \
- && rm -rf openshift-* oc.tgz \
+ && wget --no-verbose -O oc.tgz https://github.com/okd-project/okd/releases/download/4.11.0-0.okd-2022-12-02-145640/openshift-client-linux-4.11.0-0.okd-2022-12-02-145640.tar.gz \
+ && mkdir "oc-dir" \
+ && tar -C "oc-dir" -xf oc.tgz \
+ && install oc-dir/oc /usr/local/bin \
+ && rm -rf "oc-dir" oc.tgz \
  && command -v oc
 
 # helm

--- a/images/stackrox-test.Dockerfile
+++ b/images/stackrox-test.Dockerfile
@@ -82,10 +82,11 @@ RUN set -ex \
 
 # oc
 RUN set -ex \
- && wget --no-verbose -O oc.tgz https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz \
- && tar -xf oc.tgz \
- && install openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit/oc /usr/local/bin \
- && rm -rf openshift-* oc.tgz \
+ && wget --no-verbose -O oc.tgz https://github.com/okd-project/okd/releases/download/4.11.0-0.okd-2022-12-02-145640/openshift-client-linux-4.11.0-0.okd-2022-12-02-145640.tar.gz \
+ && mkdir "oc-dir" \
+ && tar -C "oc-dir" -xf oc.tgz \
+ && install oc-dir/oc /usr/local/bin \
+ && rm -rf "oc-dir" oc.tgz \
  && command -v oc
 
 # helm


### PR DESCRIPTION
Hoping a more recent version of `oc` will be able to fetch kube API server audit logs, [unlike the current one](https://github.com/stackrox/stackrox/pull/4377) we use.

The currently used version of `oc` was over 4 years old, so I fully expect some trouble rolling this out, as some functionality might have changed.

Tested by running `make stackrox-build-image stackrox-test-image` locally.
