### PR TITLE
update README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
-[![CircleCI][circleci-badge]][circleci-link]
-[![Docker Hub][docker-badge]][docker-link]
+[![GitHub Action][gha-badge]][gha-link]
 
 # StackRox CI & Build Images
 
 This repository holds the Dockerfiles for images used in StackRox CI & builds.
 
-[circleci-badge]: https://circleci.com/gh/stackrox/rox-ci-image.svg?&style=shield&circle-token=f9c93b8793b8d77af175d0f34a200fe7261212d2
-[circleci-link]:  https://circleci.com/gh/stackrox/workflows/rox-ci-image/tree/master
-[docker-badge]:   https://img.shields.io/badge/docker-hub-blue.svg
-[docker-link]:    https://hub.docker.com/r/stackrox/apollo-ci/tags/
+[gha-badge]: https://github.com/stackrox/rox-ci-image/actions/workflows/build.yaml/badge.svg
+[gha-link]:  https://github.com/stackrox/rox-ci-image/actions/workflows/build.yaml
+


### PR DESCRIPTION
Replace CircleCI with GHA. I could not determine an equivalent badge for Quay, so I just left it out