### PR TITLE
Make RocksDB build portable

### DIFF
--- a/images/rocksdb.Dockerfile
+++ b/images/rocksdb.Dockerfile
@@ -19,7 +19,7 @@ RUN dnf update -y && \
     rm -rf /var/cache/dnf /var/cache/yum
 
 # This compiles RocksDB without BMI and AVX2 instructions
-ENV PORTABLE=1 TRY_SSE_ETC=0 TRY_SSE42="-msse4.2" TRY_PCLMUL="-mpclmul" CXXFLAGS="-fPIC"
+ENV PORTABLE=1 CXXFLAGS="-fPIC"
 
 ARG ROCKSDB_VERSION="v6.7.3"
 RUN mkdir -p /build && \


### PR DESCRIPTION
Now that Postgres is shipping in 4.0, we can make this portable which allows mac users to run stackrox with images built from upstream CI