### PR TITLE
ROX-17052: Update Go from 1.20.3 to 1.20.4

### DIFF
--- a/images/stackrox-build.Dockerfile
+++ b/images/stackrox-build.Dockerfile
@@ -38,8 +38,8 @@ RUN dnf update -y && \
     dnf clean all && \
     rm -rf /var/cache/dnf /var/cache/yum
 
-ARG GOLANG_VERSION=1.20.3
-ARG GOLANG_SHA256=979694c2c25c735755bf26f4f45e19e64e4811d661dd07b8c010f7a8e18adfca
+ARG GOLANG_VERSION=1.20.4
+ARG GOLANG_SHA256=698ef3243972a51ddb4028e4a1ac63dc6d60821bf18e59a807e051fee0a385bd
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 RUN url="https://dl.google.com/go/go${GOLANG_VERSION}.linux-amd64.tar.gz" && \


### PR DESCRIPTION
Upgrading to Go 1.20.4 addresses the CVE-2023-24540.

(ignore the branch name, this PR has been repurposed).