### PR TITLE
ROX-14204: Add non-root user to the test image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -56,6 +56,9 @@ jobs:
       - uses: ./.github/actions/build-and-push-image
         with:
           image-flavor: "stackrox-test"
+      - uses: ./.github/actions/build-and-push-image
+        with:
+          image-flavor: "stackrox-test-user"
 
   build-and-push-collector:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ stackrox-test-image:
 		-f images/stackrox-test.Dockerfile \
 		images/
 
-STACKROX_TEST_GHA_TAG=$(shell scripts/get_tag.sh "stackrox-test-gha")
+STACKROX_TEST_GHA_TAG=$(shell scripts/get_tag.sh "stackrox-test-user")
 
 .PHONY: stackrox-test-user-image
 stackrox-test-user-image:

--- a/Makefile
+++ b/Makefile
@@ -38,12 +38,12 @@ stackrox-test-image:
 		-f images/stackrox-test.Dockerfile \
 		images/
 
-STACKROX_TEST_GHA_TAG=$(shell scripts/get_tag.sh "stackrox-test-user")
+STACKROX_TEST_USER_TAG=$(shell scripts/get_tag.sh "stackrox-test-user")
 
 .PHONY: stackrox-test-user-image
 stackrox-test-user-image:
 	$(DOCKER) build \
-		-t quay.io/$(QUAY_REPO)/apollo-ci:$(STACKROX_TEST_GHA_TAG) \
+		-t quay.io/$(QUAY_REPO)/apollo-ci:$(STACKROX_TEST_USER_TAG) \
 		--build-arg BASE_TAG=$(STACKROX_BUILD_TAG) \
 		-f images/stackrox-user.Dockerfile \
 		images/

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,16 @@ stackrox-test-image:
 		-f images/stackrox-test.Dockerfile \
 		images/
 
+STACKROX_TEST_GHA_TAG=$(shell scripts/get_tag.sh "stackrox-test-gha")
+
+.PHONY: stackrox-test-user-image
+stackrox-test-user-image:
+	$(DOCKER) build \
+		-t quay.io/$(QUAY_REPO)/apollo-ci:$(STACKROX_TEST_GHA_TAG) \
+		--build-arg BASE_TAG=$(STACKROX_BUILD_TAG) \
+		-f images/stackrox-user.Dockerfile \
+		images/
+
 .PHONY: test-cci-export
 test-cci-export:
 	$(DOCKER) build \

--- a/images/stackrox-test.Dockerfile
+++ b/images/stackrox-test.Dockerfile
@@ -159,3 +159,8 @@ RUN set -ex \
 RUN \
 	mv /bin/bash /bin/real-bash && \
 	mv /bin/bash-wrapper /bin/bash
+
+RUN groupadd testgroup && \
+    useradd --gid testgroup --shell /bin/bash --create-home testuser
+
+USER testuser

--- a/images/stackrox-test.Dockerfile
+++ b/images/stackrox-test.Dockerfile
@@ -159,8 +159,3 @@ RUN set -ex \
 RUN \
 	mv /bin/bash /bin/real-bash && \
 	mv /bin/bash-wrapper /bin/bash
-
-RUN groupadd testgroup && \
-    useradd --gid testgroup --shell /bin/bash --create-home testuser
-
-USER testuser

--- a/images/stackrox-user.Dockerfile
+++ b/images/stackrox-user.Dockerfile
@@ -1,0 +1,7 @@
+ARG BASE_TAG
+FROM quay.io/rhacs-eng/apollo-ci:${BASE_TAG}
+
+RUN groupadd stackrox && \
+    useradd --gid stackrox --shell /bin/bash --create-home stackrox
+
+USER stackrox

--- a/images/stackrox-user.Dockerfile
+++ b/images/stackrox-user.Dockerfile
@@ -3,5 +3,3 @@ FROM quay.io/rhacs-eng/apollo-ci:${BASE_TAG}
 
 RUN groupadd stackrox && \
     useradd --gid stackrox --shell /bin/bash --create-home stackrox
-
-USER stackrox


### PR DESCRIPTION
This is to make the tests run with limited permissions, so that some file operations could be restricted for some test purposes. See ROX-14204.