### PR TITLE
Update Bats to 1.10.0

### DIFF
--- a/images/stackrox-test.Dockerfile
+++ b/images/stackrox-test.Dockerfile
@@ -61,7 +61,7 @@ ENV PATH=$PATH:/usr/pgsql-14/bin
 
 # Install bats
 RUN set -ex \
-  && npm install -g bats@1.10.0 bats-support@0.3.0 bats-assert@2.1.0 tap-junit \
+  && npm install -g bats@1.10.0 bats-support@0.3.0 bats-assert@2.0.0 tap-junit \
   && bats -v
 
 # Install docker binary

--- a/images/stackrox-test.Dockerfile
+++ b/images/stackrox-test.Dockerfile
@@ -61,7 +61,7 @@ ENV PATH=$PATH:/usr/pgsql-14/bin
 
 # Install bats
 RUN set -ex \
-  && npm install -g bats@1.5.0 bats-support@0.3.0 bats-assert@2.0.0 tap-junit \
+  && npm install -g bats@1.10.0 bats-support@0.3.0 bats-assert@2.1.0 tap-junit \
   && bats -v
 
 # Install docker binary


### PR DESCRIPTION
While running bats tests locally (version 1.10.0), some scanner tests produced a warning:

```
BW02: Using flags on `run` requires at least BATS_VERSION=1.5.0. Use `bats_require_minimum_version 1.5.0` to fix
```

However, adding the call to `bats_require_minimum_version 1.5.0` requires version of at least `1.7.0`. So instead updating to 1.7.0, I decided to update to the newest available versions of bats core, support, and assert.
