### PR TITLE
bump go to 1.20.12

### DIFF
--- a/images/collector.Dockerfile
+++ b/images/collector.Dockerfile
@@ -37,8 +37,8 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 # Install pip
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py
 
-ARG GOLANG_VERSION=1.20.3
-ARG GOLANG_SHA256=979694c2c25c735755bf26f4f45e19e64e4811d661dd07b8c010f7a8e18adfca
+ARG GOLANG_VERSION=1.20.12
+ARG GOLANG_SHA256=9c5d48c54dd8b0a3b2ef91b0f92a1190aa01f11d26e98033efa64c46a30bba7b
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 RUN url="https://dl.google.com/go/go${GOLANG_VERSION}.linux-amd64.tar.gz" && \

--- a/images/scanner-build.Dockerfile
+++ b/images/scanner-build.Dockerfile
@@ -10,8 +10,8 @@ RUN dnf update -y && \
     dnf clean all && \
     rm -rf /var/cache/dnf /var/cache/yum
 
-ARG GOLANG_VERSION=1.20.3
-ARG GOLANG_SHA256=979694c2c25c735755bf26f4f45e19e64e4811d661dd07b8c010f7a8e18adfca
+ARG GOLANG_VERSION=1.20.12
+ARG GOLANG_SHA256=9c5d48c54dd8b0a3b2ef91b0f92a1190aa01f11d26e98033efa64c46a30bba7b
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 RUN url="https://dl.google.com/go/go${GOLANG_VERSION}.linux-amd64.tar.gz" && \

--- a/images/stackrox-build.Dockerfile
+++ b/images/stackrox-build.Dockerfile
@@ -38,8 +38,8 @@ RUN dnf update -y && \
     dnf clean all && \
     rm -rf /var/cache/dnf /var/cache/yum
 
-ARG GOLANG_VERSION=1.20.4
-ARG GOLANG_SHA256=698ef3243972a51ddb4028e4a1ac63dc6d60821bf18e59a807e051fee0a385bd
+ARG GOLANG_VERSION=1.20.12
+ARG GOLANG_SHA256=9c5d48c54dd8b0a3b2ef91b0f92a1190aa01f11d26e98033efa64c46a30bba7b
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 RUN url="https://dl.google.com/go/go${GOLANG_VERSION}.linux-amd64.tar.gz" && \


### PR DESCRIPTION
Update Go to latest downstream available 1.20 version. 

0.3.59 build image is used in upstream 4.3.
Reason for branching off is to avoid any modifications between 0.3.59..0.3.69 (removal of rocksdb, ...).