### PR TITLE
Update centos to stream9

### DIFF
--- a/STACKROX_CENTOS_TAG
+++ b/STACKROX_CENTOS_TAG
@@ -1,1 +1,1 @@
-stream8
+stream9

--- a/images/collector.Dockerfile
+++ b/images/collector.Dockerfile
@@ -20,7 +20,7 @@ RUN dnf update -y && \
         google-cloud-cli \
         jq \
         procps-ng \
-        python38 \
+        python3.12 \
         wget \
         docker-ce \
         docker-ce-cli \

--- a/images/collector.Dockerfile
+++ b/images/collector.Dockerfile
@@ -10,8 +10,7 @@ RUN set -ex \
   && rm -r /static-tmp
 
 RUN dnf update -y && \
-    dnf install -y epel-release dnf-plugins-core && \
-    dnf config-manager --set-enabled crb && \
+    dnf install -y dnf-plugins-core && \
     dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo && \
     dnf -y groupinstall "Development Tools" && \
     dnf install -y \

--- a/images/collector.Dockerfile
+++ b/images/collector.Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream8
+FROM quay.io/centos/centos:stream9
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -11,7 +11,7 @@ RUN set -ex \
 
 RUN dnf update -y && \
     dnf install -y epel-release dnf-plugins-core && \
-    dnf config-manager --set-enabled powertools && \
+    dnf config-manager --set-enabled crb && \
     dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo && \
     dnf -y groupinstall "Development Tools" && \
     dnf install -y \

--- a/images/scanner-build.Dockerfile
+++ b/images/scanner-build.Dockerfile
@@ -1,6 +1,6 @@
 # Provides the tooling required to run Scanner dockerized build targets.
 
-FROM quay.io/centos/centos:stream8
+FROM quay.io/centos/centos:stream9
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/images/stackrox-build.Dockerfile
+++ b/images/stackrox-build.Dockerfile
@@ -13,7 +13,7 @@ RUN dnf update -y && \
         epel-release \
         wget \
         && \
-    dnf config-manager --set-enabled powertools && \
+    dnf config-manager --set-enabled crb && \
     dnf update -y && \
     wget --quiet -O - https://rpm.nodesource.com/setup_lts.x | bash - && \
     wget --quiet -O - https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo && \

--- a/images/stackrox-build.Dockerfile
+++ b/images/stackrox-build.Dockerfile
@@ -30,6 +30,7 @@ RUN dnf update -y && \
         snappy-devel \
         yarn \
         zlib-devel \
+        glibc-static \
         && \
     dnf upgrade -y && \
     dnf clean all && \


### PR DESCRIPTION
It looks like mirrorlist.centos.org release 8-stream is not available anymore:
```
0.271   - Curl error (6): Couldn't resolve host name for http://mirrorlist.centos.org/?release=8-stream&arch=aarch64&repo=AppStream&infra=container [Could not resolve host: mirrorlist.centos.org]
0.275 Error: Failed to download metadata for repo 'appstream': Cannot prepare internal mirrorlist: Curl error (6): Couldn't resolve host name for http://mirrorlist.centos.org/?release=8-stream&arch=aarch64&repo=AppStream&infra=container [Could not resolve host: mirrorlist.centos.org]
```

Updating to centos stream9 in order to fix the issue