### PR TITLE
ROX-20769: Add PG flavor to the stackrox-test image

### DIFF
--- a/images/stackrox-test.Dockerfile
+++ b/images/stackrox-test.Dockerfile
@@ -45,16 +45,15 @@ RUN dnf update -y \
         xz \
         zip \
   && dnf remove -y java-1.8.0-openjdk-headless \
+  && dnf --disablerepo="*" --enablerepo="pgdg13" install -y postgresql13 postgresql13-server postgresql13-contrib \
   && dnf --disablerepo="*" --enablerepo="pgdg14" install -y postgresql14 postgresql14-server postgresql14-contrib \
+  && dnf --disablerepo="*" --enablerepo="pgdg15" install -y postgresql15 postgresql15-server postgresql15-contrib \
   && dnf clean all \
   && rm -rf /var/cache/dnf /var/cache/yum
 
 # Use updated auth plugin for GCP
 ENV USE_GKE_GCLOUD_AUTH_PLUGIN=True
 RUN gke-gcloud-auth-plugin --version
-
-# Update PATH for Postgres14
-ENV PATH=$PATH:/usr/pgsql-14/bin
 
 # Install bats
 RUN set -ex \


### PR DESCRIPTION
stackrox-test image is used to run go-postgres tests and has PostgreSQL installed for that purposes. Now we come to the point that ACS has to be tested against multiple versions. To support that, produce images with a specified PG version in the form
"stackrox-test-$(TEST_TAG)-pg$(PG_VERSION)". The main image will stay there without any changes, and only a consumer CI pipeline that would like to exercise different versions will pick it up.