### PR TITLE
Update "latest" tagged images on new tag

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,6 +37,13 @@ jobs:
         id: build-and-push-image
         with:
           image-flavor: "${{ matrix.image-flavor }}"
+      - name: Push latest tag
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          IMAGE="${{ steps.build-and-push-image.outputs.image-tag }}"
+          LATEST_IMAGE="quay.io/stackrox-io/apollo-ci:${{ matrix.image-flavor }}-latest"
+          docker tag "${IMAGE}" "${LATEST_IMAGE}"
+          docker push "${LATEST_IMAGE}"
       - name: Save image info
         run: |
           mkdir -p image-info
@@ -67,6 +74,13 @@ jobs:
         id: build-and-push-image
         with:
           image-flavor: "${{ matrix.image-flavor }}"
+      - name: Push latest tag
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          IMAGE="${{ steps.build-and-push-image.outputs.image-tag }}"
+          LATEST_IMAGE="quay.io/stackrox-io/apollo-ci:${{ matrix.image-flavor }}-latest"
+          docker tag "${IMAGE}" "${LATEST_IMAGE}"
+          docker push "${LATEST_IMAGE}"
       - name: Save image info
         run: |
           mkdir -p image-info

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,7 +47,7 @@ jobs:
           CURRENT="${{ github.ref_name }}"
           LATEST="$(git tag --merged origin/main --sort=-version:refname | head -1)"
           if [[ "${CURRENT}" != "${LATEST}" ]]; then
-            echo "Skipping latest push: ${CURRENT} is not the newest tag on main (${LATEST} is)"
+            echo "Skipping latest push: ${CURRENT} is not the highest version tag on main (${LATEST} is)"
             exit 0
           fi
           IMAGE="${{ steps.build-and-push-image.outputs.image-tag }}"
@@ -94,7 +94,7 @@ jobs:
           CURRENT="${{ github.ref_name }}"
           LATEST="$(git tag --merged origin/main --sort=-version:refname | head -1)"
           if [[ "${CURRENT}" != "${LATEST}" ]]; then
-            echo "Skipping latest push: ${CURRENT} is not the newest tag on main (${LATEST} is)"
+            echo "Skipping latest push: ${CURRENT} is not the highest version tag on main (${LATEST} is)"
             exit 0
           fi
           IMAGE="${{ steps.build-and-push-image.outputs.image-tag }}"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,6 +40,12 @@ jobs:
       - name: Push latest tag
         if: startsWith(github.ref, 'refs/tags/')
         run: |
+          CURRENT="${{ github.ref_name }}"
+          LATEST="$(git tag --merged origin/main --sort=-version:refname | head -1)"
+          if [[ "${CURRENT}" != "${LATEST}" ]]; then
+            echo "Skipping latest push: ${CURRENT} is not the newest tag on main (${LATEST} is)"
+            exit 0
+          fi
           IMAGE="${{ steps.build-and-push-image.outputs.image-tag }}"
           LATEST_IMAGE="quay.io/stackrox-io/apollo-ci:${{ matrix.image-flavor }}-latest"
           docker tag "${IMAGE}" "${LATEST_IMAGE}"
@@ -77,6 +83,12 @@ jobs:
       - name: Push latest tag
         if: startsWith(github.ref, 'refs/tags/')
         run: |
+          CURRENT="${{ github.ref_name }}"
+          LATEST="$(git tag --merged origin/main --sort=-version:refname | head -1)"
+          if [[ "${CURRENT}" != "${LATEST}" ]]; then
+            echo "Skipping latest push: ${CURRENT} is not the newest tag on main (${LATEST} is)"
+            exit 0
+          fi
           IMAGE="${{ steps.build-and-push-image.outputs.image-tag }}"
           LATEST_IMAGE="quay.io/stackrox-io/apollo-ci:${{ matrix.image-flavor }}-latest"
           docker tag "${IMAGE}" "${LATEST_IMAGE}"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,6 +40,10 @@ jobs:
       - name: Push latest tag
         if: startsWith(github.ref, 'refs/tags/')
         run: |
+          if ! git merge-base --is-ancestor "${{ github.sha }}" origin/main; then
+            echo "Skipping latest push: tagged commit is not on main"
+            exit 0
+          fi
           CURRENT="${{ github.ref_name }}"
           LATEST="$(git tag --merged origin/main --sort=-version:refname | head -1)"
           if [[ "${CURRENT}" != "${LATEST}" ]]; then
@@ -83,6 +87,10 @@ jobs:
       - name: Push latest tag
         if: startsWith(github.ref, 'refs/tags/')
         run: |
+          if ! git merge-base --is-ancestor "${{ github.sha }}" origin/main; then
+            echo "Skipping latest push: tagged commit is not on main"
+            exit 0
+          fi
           CURRENT="${{ github.ref_name }}"
           LATEST="$(git tag --merged origin/main --sort=-version:refname | head -1)"
           if [[ "${CURRENT}" != "${LATEST}" ]]; then

--- a/.github/workflows/promote-stable.yaml
+++ b/.github/workflows/promote-stable.yaml
@@ -14,25 +14,16 @@ env:
 jobs:
   promote-stable:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        image-flavor:
-          - scanner-build
-          - scanner-test
-          - stackrox-build
-          - stackrox-test
-          - stackrox-ui-test
-          - jenkins-plugin
-      fail-fast: false
     steps:
       - name: Log in to Quay
         run: |
           docker login -u "$QUAY_STACKROX_IO_RW_USERNAME" --password-stdin <<<"$QUAY_STACKROX_IO_RW_PASSWORD" quay.io
-      - name: Retag as stable
+      - name: Retag all flavors as stable
         run: |
-          SRC="quay.io/stackrox-io/apollo-ci:${{ matrix.image-flavor }}-${{ inputs.version }}"
-          DST="quay.io/stackrox-io/apollo-ci:${{ matrix.image-flavor }}-stable"
-          docker pull "${SRC}"
-          docker tag "${SRC}" "${DST}"
-          docker push "${DST}"
-          echo "Promoted ${SRC} → ${DST}"
+          VERSION="${{ inputs.version }}"
+          for flavor in scanner-build scanner-test stackrox-build stackrox-test stackrox-ui-test jenkins-plugin; do
+            SRC="quay.io/stackrox-io/apollo-ci:${flavor}-${VERSION}"
+            DST="quay.io/stackrox-io/apollo-ci:${flavor}-stable"
+            echo "Promoting ${SRC} → ${DST}"
+            docker buildx imagetools create --tag "${DST}" "${SRC}"
+          done

--- a/.github/workflows/promote-stable.yaml
+++ b/.github/workflows/promote-stable.yaml
@@ -1,9 +1,6 @@
 name: Promote to stable
 
 on:
-  push:
-    tags:
-      - "test-stable"
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/promote-stable.yaml
+++ b/.github/workflows/promote-stable.yaml
@@ -4,8 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to promote (e.g. 0.5.7)"
-        required: true
+        description: "Version to promote (e.g. 0.5.7). Defaults to 'latest'."
+        required: false
+        default: "latest"
 
 env:
   QUAY_STACKROX_IO_RW_USERNAME: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}

--- a/.github/workflows/promote-stable.yaml
+++ b/.github/workflows/promote-stable.yaml
@@ -1,6 +1,9 @@
 name: Promote to stable
 
 on:
+  push:
+    tags:
+      - "test-stable"
   workflow_dispatch:
     inputs:
       version:
@@ -22,6 +25,7 @@ jobs:
       - name: Retag all flavors as stable
         run: |
           VERSION="${{ inputs.version }}"
+          VERSION="${VERSION:-latest}"
           for flavor in scanner-build scanner-test stackrox-build stackrox-test stackrox-ui-test jenkins-plugin; do
             SRC="quay.io/stackrox-io/apollo-ci:${flavor}-${VERSION}"
             DST="quay.io/stackrox-io/apollo-ci:${flavor}-stable"

--- a/.github/workflows/promote-stable.yaml
+++ b/.github/workflows/promote-stable.yaml
@@ -1,0 +1,38 @@
+name: Promote to stable
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to promote (e.g. 0.5.7)"
+        required: true
+
+env:
+  QUAY_STACKROX_IO_RW_USERNAME: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
+  QUAY_STACKROX_IO_RW_PASSWORD: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
+
+jobs:
+  promote-stable:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image-flavor:
+          - scanner-build
+          - scanner-test
+          - stackrox-build
+          - stackrox-test
+          - stackrox-ui-test
+          - jenkins-plugin
+      fail-fast: false
+    steps:
+      - name: Log in to Quay
+        run: |
+          docker login -u "$QUAY_STACKROX_IO_RW_USERNAME" --password-stdin <<<"$QUAY_STACKROX_IO_RW_PASSWORD" quay.io
+      - name: Retag as stable
+        run: |
+          SRC="quay.io/stackrox-io/apollo-ci:${{ matrix.image-flavor }}-${{ inputs.version }}"
+          DST="quay.io/stackrox-io/apollo-ci:${{ matrix.image-flavor }}-stable"
+          docker pull "${SRC}"
+          docker tag "${SRC}" "${DST}"
+          docker push "${DST}"
+          echo "Promoted ${SRC} → ${DST}"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Each image flavor (e.g. `stackrox-test`, `scanner-test`) is pushed to
 | Tag | Example | Updated when | Use in |
 |-----|---------|-------------|--------|
 | **versioned** | `stackrox-test-0.5.7` | Every merge to main (auto-tagged) | Release branch prow configs, pinned references |
-| **latest** | `stackrox-test-latest` | Every new version tag on main | Testing PRs against openshift/release (never merge with this tag) |
+| **latest** | `stackrox-test-latest` | Every new version tag on main | Testing rox-ci-image version in openshift/release PRs with `/pj-rehearse` before promoting to stable. |
 | **stable** | `stackrox-test-stable` | Manual promotion via workflow | Master/nightly prow configs in openshift/release |
 
 ### How it works

--- a/README.md
+++ b/README.md
@@ -7,6 +7,55 @@ This repository holds the Dockerfiles for images used in StackRox CI & builds.
 [gha-badge]: https://github.com/stackrox/rox-ci-image/actions/workflows/build.yaml/badge.svg
 [gha-link]:  https://github.com/stackrox/rox-ci-image/actions/workflows/build.yaml
 
+## Image Tags and Release Process
+
+Each image flavor (e.g. `stackrox-test`, `scanner-test`) is pushed to
+`quay.io/stackrox-io/apollo-ci` with three types of tags:
+
+| Tag | Example | Updated when | Use in |
+|-----|---------|-------------|--------|
+| **versioned** | `stackrox-test-0.5.7` | Every merge to main (auto-tagged) | Release branch prow configs, pinned references |
+| **latest** | `stackrox-test-latest` | Every new version tag on main | Testing PRs against openshift/release (never merge with this tag) |
+| **stable** | `stackrox-test-stable` | Manual promotion via workflow | Master/nightly prow configs in openshift/release |
+
+### How it works
+
+1. **Merge to main** -- `tag.yaml` auto-creates a semver tag (e.g. `0.5.8`)
+2. **Tag push** -- `build.yaml` builds all images, pushes versioned tags, and
+   updates `latest` (only if the tag is the highest version on main)
+3. **Promote to stable** -- run manually when ready:
+   ```bash
+   gh workflow run promote-stable.yaml
+   # or with a specific version:
+   gh workflow run promote-stable.yaml -f version=0.5.8
+   ```
+   This does a server-side retag (no rebuild) of all image flavors from the
+   specified version (default: `latest`) to `stable`.
+
+### Updating prow jobs in openshift/release
+
+Prow job configs in `openshift/release` reference these images via
+`build_root.image_stream_tag`. The tags must first be mirrored in
+`core-services/image-mirroring/_config.yaml`.
+
+- **Master/nightly configs**: use `stable` tag -- automatically picks up
+  promoted versions without config changes.
+- **Release branch configs**: pin to a specific version (e.g. `scanner-test-0.5.7`)
+  for reproducibility.
+- **`latest` tag**: use only for testing PRs against openshift/release.
+  `latest` is a moving target and should not be used for required jobs --
+  it is intended only for validation before promoting to `stable`.
+
+### Mirroring new versions to openshift CI
+
+To mirror a new versioned tag for release branch use:
+
+1. Add an entry to `core-services/image-mirroring/_config.yaml` in openshift/release
+2. PR requires testplatform team review (use `/cc @jmguzik` to request)
+
+The `latest` and `stable` floating tags are mirrored once and do not need
+updates per version.
+
 ## Updating the Go Version
 
 To bump the Go version across all Docker images in this repository, use the automated script:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Each image flavor (e.g. `stackrox-test`, `scanner-test`) is pushed to
 1. **Merge to main** -- `tag.yaml` auto-creates a semver tag (e.g. `0.5.8`)
 2. **Tag push** -- `build.yaml` builds all images, pushes versioned tags, and
    updates `latest` (only if the tag is the highest version on main)
-3. **Promote to stable** -- run manually when ready:
+3. **Promote to stable** -- [run manually](https://github.com/stackrox/rox-ci-image/actions/workflows/promote-stable.yaml) when ready:
    ```bash
    gh workflow run promote-stable.yaml
    # or with a specific version:

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Prow job configs in `openshift/release` reference these images via
 To mirror a new versioned tag for release branch use:
 
 1. Add an entry to `core-services/image-mirroring/_config.yaml` in openshift/release
-2. PR requires testplatform team review (use `/cc @jmguzik` to request)
+2. PR requires testplatform team review
 
 The `latest` and `stable` floating tags are mirrored once and do not need
 updates per version.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Prow job configs in `openshift/release` reference these images via
 `build_root.image_stream_tag`. The tags must first be mirrored in
 `core-services/image-mirroring/_config.yaml`.
 
-- **Master/nightly configs**: use `stable` tag -- automatically picks up
+- **Master/nightly configs**: use `stable` tag -- periodically, automatically picks up
   promoted versions without config changes.
 - **Release branch configs**: pin to a specific version (e.g. `scanner-test-0.5.7`)
   for reproducibility.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Each image flavor (e.g. `stackrox-test`, `scanner-test`) is pushed to
 
 ### Updating prow jobs in openshift/release
 
-Prow job configs in `openshift/release` reference these images via
+Prow [job configs](https://github.com/openshift/release/tree/main/ci-operator/config/stackrox/stackrox) in the `openshift/release` repository reference these images via
 `build_root.image_stream_tag`. The tags must first be mirrored in
 `core-services/image-mirroring/_config.yaml`.
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,30 @@ To mirror a new versioned tag for release branch use:
 The `latest` and `stable` floating tags are mirrored once and do not need
 updates per version.
 
+## Step-by-step: Making a CI Image Change
+
+Example: you need to bump a dependency or add a tool to the CI image.
+
+1. **Make your change** on a branch and open a PR in this repo.
+2. **Merge to main** -- once approved, merge the PR. The `tag.yaml` workflow
+   auto-creates a semver tag (e.g. `0.5.8`).
+3. **Wait for the build** -- the `build.yaml` workflow builds all image flavors
+   and pushes both versioned and `latest` tags to quay.io.
+4. **Test in openshift/release** -- open a PR in `openshift/release` that
+   references the `latest` tag and run `/pj-rehearse` to validate affected
+   prow jobs. No config change is needed if the jobs already use `latest`.
+5. **Promote to stable** -- once rehearsals pass, [run the promote-stable
+   workflow](https://github.com/stackrox/rox-ci-image/actions/workflows/promote-stable.yaml)
+   (or `gh workflow run promote-stable.yaml`). This retags `latest` → `stable`.
+   Master/nightly prow jobs pick up the new image automatically.
+6. **Pin release branches** (if needed) -- for release branch configs, update
+   `openshift/release` to reference the specific versioned tag
+   (e.g. `stackrox-test-0.5.8`). This requires testplatform review.
+
+> **Note:** There is only one `latest` tag per flavor, so only one
+> rox-ci-image change can be tested via rehearsal at a time. Coordinate
+> with others if multiple changes are in flight.
+
 ## Updating the Go Version
 
 To bump the Go version across all Docker images in this repository, use the automated script:


### PR DESCRIPTION
## Summary
- On tag pushes, also push a `<flavor>-latest` tag alongside the versioned tag.
- add on-demand workflow to push `<flavor>-stable` tag based on a version[default is latest]

This allows openshift-release mirror config to reference the floating tags `latest` and `stable`, removing the need to request testplatform review for every version bump.
To use this: https://github.com/openshift/release/pull/77606 adds the "-latest"(and -stable) image mirroring into the openshift-release config, and then tests will be able to use a "latest" or "stable" tagged rox-ci-image.

## Test plan
- [x] Verify PR build does NOT push latest tags
- [x] Verify tag/main push DOES push latest tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)