### PR TITLE
Push stable tags as plain images instead of manifest lists

### DIFF
--- a/.github/workflows/promote-stable.yaml
+++ b/.github/workflows/promote-stable.yaml
@@ -7,6 +7,10 @@ on:
         description: "Version to promote (e.g. 0.5.7). Defaults to 'latest'."
         required: false
         default: "latest"
+      target:
+        description: "Target tag suffix (e.g. 'stable', 'stable-test'). Defaults to 'stable'."
+        required: false
+        default: "stable"
 
 env:
   QUAY_STACKROX_IO_RW_USERNAME: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
@@ -25,7 +29,9 @@ jobs:
           VERSION="${VERSION:-latest}"
           for flavor in scanner-build scanner-test stackrox-build stackrox-test stackrox-ui-test jenkins-plugin; do
             SRC="quay.io/stackrox-io/apollo-ci:${flavor}-${VERSION}"
-            DST="quay.io/stackrox-io/apollo-ci:${flavor}-stable"
+            TARGET="${{ inputs.target }}"
+            TARGET="${TARGET:-stable}"
+            DST="quay.io/stackrox-io/apollo-ci:${flavor}-${TARGET}"
             echo "Promoting ${SRC} → ${DST}"
             skopeo copy "docker://${SRC}" "docker://${DST}"
           done

--- a/.github/workflows/promote-stable.yaml
+++ b/.github/workflows/promote-stable.yaml
@@ -27,5 +27,7 @@ jobs:
             SRC="quay.io/stackrox-io/apollo-ci:${flavor}-${VERSION}"
             DST="quay.io/stackrox-io/apollo-ci:${flavor}-stable"
             echo "Promoting ${SRC} → ${DST}"
-            docker buildx imagetools create --tag "${DST}" "${SRC}"
+            docker pull "${SRC}"
+            docker tag "${SRC}" "${DST}"
+            docker push "${DST}"
           done

--- a/.github/workflows/promote-stable.yaml
+++ b/.github/workflows/promote-stable.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Log in to Quay
         run: |
-          docker login -u "$QUAY_STACKROX_IO_RW_USERNAME" --password-stdin <<<"$QUAY_STACKROX_IO_RW_PASSWORD" quay.io
+          skopeo login -u "$QUAY_STACKROX_IO_RW_USERNAME" --password-stdin <<<"$QUAY_STACKROX_IO_RW_PASSWORD" quay.io
       - name: Retag all flavors as stable
         run: |
           VERSION="${{ inputs.version }}"
@@ -27,7 +27,5 @@ jobs:
             SRC="quay.io/stackrox-io/apollo-ci:${flavor}-${VERSION}"
             DST="quay.io/stackrox-io/apollo-ci:${flavor}-stable"
             echo "Promoting ${SRC} → ${DST}"
-            docker pull "${SRC}"
-            docker tag "${SRC}" "${DST}"
-            docker push "${DST}"
+            skopeo copy "docker://${SRC}" "docker://${DST}"
           done


### PR DESCRIPTION
## Summary
- The `promote-stable` workflow used `docker buildx imagetools create` to retag images as stable, which wraps the single-arch amd64 image in a manifest list
- This prevents arm64 clients (e.g. Apple Silicon with emulation) from pulling the image — they get "no matching manifest for linux/arm64" instead of falling back to amd64
- Use `skopeo copy` for a server-side retag that preserves the original plain image format without pulling locally
- Also adds a configurable `target` input (defaults to "stable") for testing promotions without affecting real stable tags

## Test

Ran the workflow on this branch with `target: stable-test` and verified on an arm64 host:

```
$ docker run --rm quay.io/stackrox-io/apollo-ci:stackrox-test-stable-test roxie version
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
roxie version v0.4.0 (2026-05-18T17:52:18Z)
```

Same digest as `stackrox-test-latest` (`sha256:387346914505c40f2018b4c2194358320673c1a2ad0e511e368cae6a1b506f2f`), pulls successfully with emulation instead of failing with "no matching manifest".

🤖 Generated with [Claude Code](https://claude.com/claude-code)